### PR TITLE
修复计算仓位时重复计算理财账户问题

### DIFF
--- a/risk_manager.py
+++ b/risk_manager.py
@@ -42,7 +42,7 @@ class AdvancedRiskManager:
             self.trader.trade_log.error("交易对信息未初始化")
             return 0
         base_amount = (
-            float(balance.get('total', {}).get(self.trader.symbol_info['base'], 0)) +
+            float(balance.get('free', {}).get(self.trader.symbol_info['base'], 0)) +
             float(funding_balance.get(self.trader.symbol_info['base'], 0))
         )
         current_price = await self.trader._get_latest_price()
@@ -56,7 +56,7 @@ class AdvancedRiskManager:
             funding_balance = await self.trader.exchange.fetch_funding_balance()
             
             usdt_balance = (
-                float(balance.get('total', {}).get('USDT', 0)) +
+                float(balance.get('free', {}).get('USDT', 0)) +
                 float(funding_balance.get('USDT', 0))
             )
             


### PR DESCRIPTION
经测试ccxt的fetch_balance方法返回结果中'total'字段包含了理财账户余额，后续又计算了一次理财账户，导致重复计算：
```
        base_amount = (
            float(balance.get('total', {}).get(self.trader.symbol_info['base'], 0)) +
            float(funding_balance.get(self.trader.symbol_info['base'], 0))
        )
```
改用'free'字段中的数据解决此问题，经测试仓位计算正确。
