### PR TITLE
修复在position_controller_s1.py中调用await self.trader.exchange.create_market_order 但在exchange_client.py中并无这个函数的BUG

### DIFF
--- a/exchange_client.py
+++ b/exchange_client.py
@@ -201,7 +201,39 @@ class ExchangeClient:
         except Exception as e:
             self.logger.error(f"下单失败: {str(e)}")
             raise
-    
+
+    async def create_market_order(
+        self,
+        symbol: str,
+        side: str,          # 只能是 'buy' 或 'sell'
+        amount: float,
+        params: dict | None = None
+    ):
+        """
+        业务层需要的『市价单快捷封装』。
+        实际还是调 ccxt 的 create_order，只是把 type 固定为 'market'。
+        """
+        # 确保有 params 字典
+        params = params or {}
+
+        # 下单前同步时间，避免 -1021 错误
+        await self.sync_time()
+        params.update({
+            'timestamp': int(time.time() * 1000 + self.time_diff),
+            'recvWindow': 5000
+        })
+
+        order = await self.exchange.create_order(
+            symbol=symbol,
+            type='market',
+            side=side.lower(),   # ccxt 规范小写
+            amount=amount,
+            price=None,          # 市价单 price 必须是 None
+            params=params
+        )
+        return order
+
+
     async def fetch_order(self, order_id, symbol, params=None):
         if params is None:
             params = {}


### PR DESCRIPTION
position_controller_s1.py中存在调用
order = await self.trader.exchange.create_market_order(
                symbol=self.trader.symbol,
                side=side.lower(), # ccxt 通常需要小写
                amount=adjusted_amount
            )

但是order = await self.trader.exchange.create_market_order 但在exchange_client.py中并无这个函数.当运行时会出现报错

AttributeError: 'ExchangeClient' object has no attribute 'create_market_order'
    order = await self.trader.exchange.create_market_order(
  File "/root/USDT/GridBNB-USDT/position_controller_s1.py", line 160, in _execute_s1_adjustment
Traceback (most recent call last):
2025-05-12 19:22:22 [PositionControllerS1] ERROR: S1: Failed to execute adjustment order (SELL 0.04420121): 'ExchangeClient' object has no attribute 'create_market_order'
2025-05-12 19:22:22 [PositionControllerS1] INFO: S1: Placing SELL order for 0.04400000 BNB at market price (approx 689.62)...
2025-05-12 19:22:22 [PositionControllerS1] INFO: S1: Condition met for SELL adjustment.
2025-05-12 19:22:22 [PositionControllerS1] INFO: S1: High level breached. Need to SELL 0.04420121 BNB to reach 50% target.


于是加了一层封装,不影响原有交易逻辑