### PR TITLE
fix(docker): upgrade to Python 3.10 to support modern syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # 使用 Python 官方镜像
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 # 设置工作目录
 WORKDIR /app


### PR DESCRIPTION
This PR updates the base image in Dockerfile from `python:3.9-slim` to `python:3.10-slim`,
in order to support modern type annotation syntax like `dict | None` (PEP 604).

Fixes runtime TypeError in Python 3.9 environments.